### PR TITLE
chore(cd): add GitHub Actions workflow for delivery of artifacts

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,62 @@
+name: CD
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deliver-windows:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pyinstaller
+
+      - name: Build Windows .exe
+        run: |
+          pyinstaller --onefile src/pt_calc.py --windowed
+
+      - name: Deliver Windows artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: pt_calc-windows
+          path: dist/pt_calc.exe
+
+  deliver-linux:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pyinstaller
+
+      - name: Build Linux binary
+        run: |
+          pyinstaller --onefile src/pt_calc.py --distpath dist
+
+      - name: Deliver Linux artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: pt_calc-linux
+          path: dist/pt_calc


### PR DESCRIPTION
###  Summary
Adds a GitHub Actions workflow (`.github/workflows/ci.yml`) to automate Continuous Delivery for the project.

### Changes
- Two independent jobs for cross-platform delivery:
    - **windows_build**: builds the Windows .exe using PyInstaller and uploads it as the artifact `pt_calc-windows`.
    - **linux_build**: builds a Linux binary using PyInstaller and uploads it as the artifact `pt_calc-linux`.
- Both jobs run on the appropriate OS runner (`windows-latest` and `ubuntu-latest`).
- Each artifact is clearly named and downloadable from the Actions tab after the workflow completes.
- The workflow is triggered on pushes to the `main` branch, representing final delivery after CI validation.

This approach ensures a clean separation of CI (testing) and CD (delivery), while providing usable executables for both Windows and Linux platforms.